### PR TITLE
Responsive logo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="Icon.png" width="90%"/>
+  <img src="Icon.png" width="65%"/>
 </p>
 
 `QRDispenser` is a lightweight library to generate a QR code as image (`UIImage`) in your app. It uses only native components, with no dependency from other libraries. This allows you to also fork the project and write your own implementation in case you need it, without worrying about external frameworks.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="Icon.png" height="250" />
+  <img src="Icon.png" width="90%"/>
 </p>
 
 `QRDispenser` is a lightweight library to generate a QR code as image (`UIImage`) in your app. It uses only native components, with no dependency from other libraries. This allows you to also fork the project and write your own implementation in case you need it, without worrying about external frameworks.


### PR DESCRIPTION
Previously the logo had a fixed height which lead to it not being displayed properly on mobile devices. I changed the width to be relative and removed the height tag.
This way the image retains its aspect ratio independent of the display size.